### PR TITLE
change empty-receive-test-name

### DIFF
--- a/src/c1_state_machine/p5_digital_cash.rs
+++ b/src/c1_state_machine/p5_digital_cash.rs
@@ -136,7 +136,7 @@ fn sm_5_empty_spend_fails() {
 }
 
 #[test]
-fn sm_5_empty_receive_fails() {
+fn sm_5_empty_receive_works() {
 	let start = State::from([Bill { owner: User::Alice, amount: 20, serial: 0 }]);
 	let end = DigitalCashSystem::next_state(
 		&start,


### PR DESCRIPTION
as discussed in the classroom, 
the test name of empty receives is misleading
the transaction should pass, burning the bills that were spent